### PR TITLE
Remove unsupported --inbox option and dead inbox type plumbing

### DIFF
--- a/autodoist/config.py
+++ b/autodoist/config.py
@@ -34,7 +34,6 @@ class Config:
     hide_future: int = 0
     onetime: bool = False
     debug: bool = False
-    inbox: Optional[str] = None  # 'parallel', 'sequential', or None
     db_path: str = "metadata.sqlite"
     
     def __post_init__(self) -> None:
@@ -72,7 +71,6 @@ class Config:
             hide_future=args.hide_future if args.hide_future is not None else int(os.environ.get('AUTODOIST_HIDE_FUTURE', '0')),
             onetime=args.onetime or bool(os.environ.get('AUTODOIST_ONETIME')),
             debug=args.debug or bool(os.environ.get('AUTODOIST_DEBUG')),
-            inbox=args.inbox,
             db_path=os.environ.get('AUTODOIST_DB_PATH', 'metadata.sqlite'),
         )
 
@@ -138,13 +136,6 @@ def _create_parser() -> argparse.ArgumentParser:
         help='Enable debug logging',
         action='store_true'
     )
-    parser.add_argument(
-        '--inbox',
-        help='How to process the Inbox project',
-        default=None,
-        choices=['parallel', 'sequential']
-    )
-    
     return parser
 
 

--- a/autodoist/labeling.py
+++ b/autodoist/labeling.py
@@ -30,7 +30,6 @@ def parse_type_suffix(
     s_suffix: str,
     p_suffix: str,
     width: int,
-    inbox_type: Optional[str] = None
 ) -> Optional[str]:
     """
     Parse type suffix from a project/section/task name.
@@ -43,16 +42,11 @@ def parse_type_suffix(
         s_suffix: Character indicating sequential (default '-')
         p_suffix: Character indicating parallel (default '=')
         width: Max chars to look for (3 for project, 2 for section, 1 for task)
-        inbox_type: Special type to return for 'Inbox' (if set)
-        
     Returns:
         Type string like 'sss', 'sp', 's', or None if no suffix found
     """
     if name is None:
         return None
-    
-    if name == 'Inbox' and inbox_type is not None:
-        return inbox_type
     
     try:
         # Match trailing suffix characters
@@ -92,7 +86,6 @@ def get_entity_type(
     s_suffix: str,
     p_suffix: str,
     width: int,
-    inbox_type: Optional[str] = None
 ) -> tuple[Optional[str], bool]:
     """
     Get the type for an entity, detecting if it changed.
@@ -105,13 +98,11 @@ def get_entity_type(
         s_suffix: Sequential suffix char
         p_suffix: Parallel suffix char
         width: Suffix width to parse
-        inbox_type: Special type for Inbox
-        
     Returns:
         Tuple of (type_str, changed) where changed is True if type differs from DB
     """
     # Parse current type from name
-    current_type = parse_type_suffix(name, s_suffix, p_suffix, width, inbox_type)
+    current_type = parse_type_suffix(name, s_suffix, p_suffix, width)
     
     # Get stored type from DB
     old_type = db.get_type_str(entity_kind, str(entity_id))
@@ -300,8 +291,7 @@ class LabelingEngine:
         # Get project type
         project_type, project_type_changed = get_entity_type(
             self.db, 'project', str(project.id), project.name,
-            self.config.s_suffix, self.config.p_suffix, 3,
-            self.config.inbox
+            self.config.s_suffix, self.config.p_suffix, 3
         )
         
         if project_type:

--- a/tests/test_inbox_contract.py
+++ b/tests/test_inbox_contract.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from autodoist.config import Config
+from autodoist.labeling import LabelingEngine
+
+
+def test_config_rejects_inbox_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TODOIST_API_KEY", "test-token")
+
+    with pytest.raises(SystemExit):
+        Config.from_env_and_cli(["--inbox", "parallel"])
+
+
+@dataclass
+class MockProject:
+    id: str
+    name: str
+    is_inbox_project: bool = False
+
+
+class MockClient:
+    def get_all_projects(self) -> list[MockProject]:
+        return [
+            MockProject(id="inbox", name="Inbox", is_inbox_project=True),
+            MockProject(id="work", name="Work -", is_inbox_project=False),
+        ]
+
+    def get_all_sections(self) -> list[Any]:
+        return []
+
+    def get_all_tasks(self) -> list[Any]:
+        return []
+
+    def queue_label_update(self, task_id: str, labels: list[str]) -> None:
+        return None
+
+
+class MockDB:
+    def commit(self) -> None:
+        return None
+
+
+def test_labeling_engine_skips_inbox_projects(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = Config(api_key="test-token", label="next_action")
+    engine = LabelingEngine(client=MockClient(), db=MockDB(), config=config)
+
+    processed: list[str] = []
+
+    def record_project(
+        project: MockProject,
+        all_sections: list[Any],
+        all_tasks: list[Any],
+        label: str,
+    ) -> None:
+        processed.append(project.id)
+
+    monkeypatch.setattr(engine, "_process_project", record_project)
+
+    changes = engine.run()
+    assert changes == 0
+    assert processed == ["work"]


### PR DESCRIPTION
## Summary
- remove unsupported `--inbox` CLI option from autodoist config
- remove dead inbox-specific type parsing plumbing from labeling code
- add regression tests to lock the contract:
  - passing `--inbox` now fails fast
  - inbox projects remain skipped during labeling

## Why
The runtime already skipped Inbox projects, but config exposed `--inbox` and parser logic accepted inbox-specific handling. This created a misleading, dead user-facing contract.

## Testing
- `uv run pytest -q tests/test_inbox_contract.py tests/test_parallel_labeling.py tests/test_sequential_labeling.py tests/test_subtask_labeling.py tests/test_parent_id_handling.py`
- Result: 24 passed
