### PR TITLE
Use shared GTD contract for suffix parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ license = { text = "MIT" }
 authors = [
     { name = "Alexander Haselhoff", email = "xela@live.nl" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "todoist-api-python>=3.0.0",
     "requests>=2.28.1",
+    "homelab-gtd-contract @ git+https://github.com/erauner/homelab-gtd-contract.git@v0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -28,6 +29,9 @@ Repository = "https://github.com/Hoffelhas/automation-todoist"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["autodoist"]

--- a/tests/test_suffix_contract_parity.py
+++ b/tests/test_suffix_contract_parity.py
@@ -1,0 +1,19 @@
+from autodoist.labeling import parse_type_suffix
+
+
+def test_parse_type_suffix_project_cases() -> None:
+    assert parse_type_suffix("Work -", "-", "=", 3) == "sss"
+    assert parse_type_suffix("Work ==", "-", "=", 3) == "ppp"
+    assert parse_type_suffix("Work =-", "-", "=", 3) == "pss"
+    assert parse_type_suffix("Work -=-", "-", "=", 3) == "sps"
+
+
+def test_parse_type_suffix_section_and_task_padding() -> None:
+    assert parse_type_suffix("Section -", "-", "=", 2) == "xss"
+    assert parse_type_suffix("Section =", "-", "=", 2) == "xpp"
+    assert parse_type_suffix("Task -", "-", "=", 1) == "xxs"
+    assert parse_type_suffix("Task =", "-", "=", 1) == "xxp"
+
+
+def test_parse_type_suffix_without_suffix_returns_none() -> None:
+    assert parse_type_suffix("No suffix", "-", "=", 3) is None


### PR DESCRIPTION
## Summary
- switch autodoist suffix parsing internals to the shared `homelab-gtd-contract` package
- keep autodoist internal type shape unchanged via local adapter (`x/s/p` 3-char format)
- add parity tests for project/section/task suffix behavior and mixed suffix handling
- add package dependency on `homelab-gtd-contract@v0.1.0`

## Why
This removes duplicated suffix parsing logic and starts establishing a single source of truth for GTD semantics across `autodoist` and `todoist-cli`.

## Notes
- `autodoist` still pads section/task semantics to 3-char `x/s/p` internally; behavior is preserved.
- direct dependency reference is currently enabled for build metadata compatibility.

## Testing
- `uv run pytest -q tests/test_suffix_contract_parity.py tests/test_parallel_labeling.py tests/test_sequential_labeling.py tests/test_subtask_labeling.py tests/test_parent_id_handling.py tests/test_inbox_contract.py`
- Result: 27 passed
