### PR TITLE
Add singleton doing_now reconciliation across core and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ All configuration can be set via environment variables for containerized deploym
 | `AUTODOIST_P_SUFFIX` | Parallel suffix character | `=` |
 | `AUTODOIST_S_SUFFIX` | Sequential suffix character | `-` |
 | `AUTODOIST_HIDE_FUTURE` | Days to hide future tasks | 0 |
+| `AUTODOIST_DOING_NOW_LABEL` | Singleton label to enforce (keeps only one active task) | - |
 | `AUTODOIST_ONETIME` | Run once and exit | false |
 | `AUTODOIST_DEBUG` | Enable debug logging | false |
 | `AUTODOIST_DB_PATH` | Path to SQLite database | metadata.sqlite |
@@ -171,6 +172,12 @@ In addition, if you experience issues with syncing you can increase the api sync
 
 ```bash
 python -m autodoist --delay <time in seconds>
+```
+
+To enforce a singleton focus label (`doing_now`) across all active tasks:
+
+```bash
+python -m autodoist --doing-now-label doing_now
 ```
 
 For all arguments, please check out the help:

--- a/autodoist/api.py
+++ b/autodoist/api.py
@@ -219,6 +219,23 @@ class TodoistClient:
             "args": {"id": task_id, "labels": labels}
         }
         self._queue.append(data)
+
+    def get_task_v1(self, task_id: str) -> dict[str, Any]:
+        """Fetch a single task via REST API v1."""
+        response = requests.get(
+            f"https://api.todoist.com/api/v1/tasks/{task_id}",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=20,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data if isinstance(data, dict) else {}
+
+    def get_task_updated_at_v1(self, task_id: str) -> Optional[str]:
+        """Fetch `updated_at` for a task via REST API v1."""
+        payload = self.get_task_v1(task_id)
+        value = payload.get("updated_at")
+        return str(value) if value is not None else None
     
     def update_task_via_rest(self, task_id: str, **kwargs: Any) -> None:
         """

--- a/autodoist/config.py
+++ b/autodoist/config.py
@@ -4,6 +4,7 @@ Configuration management via environment variables and CLI arguments.
 Environment variables (primary for K8s/Docker):
   TODOIST_API_KEY    - Todoist API key (required)
   AUTODOIST_LABEL    - Label name for next actions
+  AUTODOIST_DOING_NOW_LABEL - Singleton label name for doing-now reconciliation
   AUTODOIST_DELAY    - Delay between syncs in seconds
   AUTODOIST_P_SUFFIX - Parallel suffix character
   AUTODOIST_S_SUFFIX - Sequential suffix character  
@@ -28,6 +29,7 @@ class Config:
     
     api_key: str
     label: Optional[str] = None
+    doing_now_label: Optional[str] = None
     delay: int = 5
     p_suffix: str = "="
     s_suffix: str = "-"
@@ -65,6 +67,11 @@ class Config:
         return cls(
             api_key=api_key,
             label=args.label if args.label is not None else os.environ.get('AUTODOIST_LABEL'),
+            doing_now_label=(
+                args.doing_now_label
+                if args.doing_now_label is not None
+                else os.environ.get('AUTODOIST_DOING_NOW_LABEL')
+            ),
             delay=args.delay if args.delay is not None else int(os.environ.get('AUTODOIST_DELAY', '5')),
             p_suffix=args.p_suffix if args.p_suffix is not None else os.environ.get('AUTODOIST_P_SUFFIX', '='),
             s_suffix=args.s_suffix if args.s_suffix is not None else os.environ.get('AUTODOIST_S_SUFFIX', '-'),
@@ -103,6 +110,13 @@ def _create_parser() -> argparse.ArgumentParser:
         '-l', '--label',
         help='Enable next action labelling with this label name',
         type=str
+    )
+    parser.add_argument(
+        '--doing_now_label', '--doing-now-label',
+        dest='doing_now_label',
+        help='Enable singleton label enforcement for this label name (e.g. doing_now)',
+        default=None,
+        type=str,
     )
     parser.add_argument(
         '-d', '--delay',

--- a/autodoist/singleton.py
+++ b/autodoist/singleton.py
@@ -1,0 +1,73 @@
+"""
+Shared helpers for singleton-label reconciliation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def parse_iso8601_to_epoch_ms(ts: Optional[str]) -> Optional[int]:
+    """Parse an ISO-8601 timestamp string to epoch milliseconds."""
+    if not ts:
+        return None
+    try:
+        value = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp() * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
+def normalize_task_id(task_id: Any) -> str:
+    return str(task_id)
+
+
+def task_updated_epoch_ms(task: Any) -> Optional[int]:
+    """Best-effort updated-at extraction from dicts or SDK model objects."""
+    updated_at = task.get("updated_at") if isinstance(task, dict) else getattr(task, "updated_at", None)
+    if isinstance(updated_at, datetime):
+        parsed = updated_at if updated_at.tzinfo is not None else updated_at.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp() * 1000)
+    if isinstance(updated_at, str):
+        return parse_iso8601_to_epoch_ms(updated_at)
+    return None
+
+
+def choose_singleton_winner(
+    tasks: list[Any],
+    *,
+    sticky_task_id: Optional[str] = None,
+    assigned_at_by_task_id: Optional[dict[str, Optional[int]]] = None,
+    preferred_task_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Pick singleton winner deterministically."""
+    if not tasks:
+        return None
+
+    if preferred_task_id is not None:
+        for task in tasks:
+            task_id = normalize_task_id(task["id"] if isinstance(task, dict) else getattr(task, "id"))
+            if task_id == preferred_task_id:
+                return task
+
+    if sticky_task_id is not None:
+        for task in tasks:
+            task_id = normalize_task_id(task["id"] if isinstance(task, dict) else getattr(task, "id"))
+            if task_id == sticky_task_id:
+                return task
+
+    assigned_lookup = assigned_at_by_task_id or {}
+
+    def rank(task: Any) -> tuple[int, int, str]:
+        task_id = normalize_task_id(task["id"] if isinstance(task, dict) else getattr(task, "id"))
+        assigned_at = assigned_lookup.get(task_id)
+        assigned_rank = assigned_at if assigned_at is not None else -1
+        updated_rank = task_updated_epoch_ms(task)
+        return (assigned_rank, updated_rank if updated_rank is not None else -1, task_id)
+
+    return max(tasks, key=rank)
+

--- a/tests/test_doing_now_singleton.py
+++ b/tests/test_doing_now_singleton.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from autodoist.config import Config
+from autodoist.db import MetadataDB
+from autodoist.labeling import LabelingEngine
+
+
+def test_config_reads_doing_now_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TODOIST_API_KEY", "test-token")
+    monkeypatch.setenv("AUTODOIST_DOING_NOW_LABEL", "doing_now")
+    config = Config.from_env_and_cli([])
+    assert config.doing_now_label == "doing_now"
+
+
+def test_config_cli_overrides_doing_now_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TODOIST_API_KEY", "test-token")
+    monkeypatch.setenv("AUTODOIST_DOING_NOW_LABEL", "from_env")
+    config = Config.from_env_and_cli(["--doing-now-label", "from_cli"])
+    assert config.doing_now_label == "from_cli"
+
+
+def test_db_singleton_state_roundtrip(tmp_path) -> None:
+    db = MetadataDB(str(tmp_path / "metadata.sqlite"), auto_commit=True)
+    db.connect()
+    try:
+        db.set_singleton_state("doing_now", "1", is_active=True, assigned_at=111)
+        db.set_singleton_state("doing_now", "2", is_active=False)
+
+        active = db.get_active_singleton_tasks("doing_now")
+        assert active == ["1"]
+        assert db.get_singleton_assigned_at("doing_now", "1") == 111
+        assert db.get_singleton_assigned_at("doing_now", "2") is None
+    finally:
+        db.close()
+
+
+@dataclass
+class MockTask:
+    id: str
+    content: str
+    project_id: str
+    section_id: Optional[str]
+    parent_id: Optional[str]
+    order: int
+    labels: list[str]
+    is_completed: bool = False
+    updated_at: Optional[str] = None
+
+
+class MockClient:
+    def __init__(self, tasks: list[MockTask]) -> None:
+        self._tasks = tasks
+        self.label_updates: list[tuple[str, list[str]]] = []
+
+    def get_all_projects(self) -> list[object]:
+        return []
+
+    def get_all_sections(self) -> list[object]:
+        return []
+
+    def get_all_tasks(self) -> list[MockTask]:
+        return self._tasks
+
+    def queue_label_update(self, task_id: str, labels: list[str]) -> None:
+        self.label_updates.append((str(task_id), list(labels)))
+
+
+def test_doing_now_conflict_keeps_recent_and_removes_loser(tmp_path) -> None:
+    tasks = [
+        MockTask(
+            id="1001",
+            content="A",
+            project_id="p",
+            section_id=None,
+            parent_id=None,
+            order=1,
+            labels=["doing_now", "next_action"],
+            updated_at="2026-02-20T10:00:00Z",
+        ),
+        MockTask(
+            id="1002",
+            content="B",
+            project_id="p",
+            section_id=None,
+            parent_id=None,
+            order=2,
+            labels=["doing_now"],
+            updated_at="2026-02-20T12:00:00Z",
+        ),
+    ]
+    client = MockClient(tasks)
+    db = MetadataDB(str(tmp_path / "metadata.sqlite"))
+    db.connect()
+    try:
+        config = Config(api_key="token", doing_now_label="doing_now")
+        engine = LabelingEngine(client=client, db=db, config=config)
+        changes = engine.run()
+
+        assert changes == 1
+        assert client.label_updates == [("1001", ["next_action"])]
+        assert db.get_active_singleton_tasks("doing_now") == ["1002"]
+    finally:
+        db.close()
+
+
+def test_main_allows_doing_now_only_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    import autodoist.__main__ as entry
+
+    config = Config(api_key="token", doing_now_label="doing_now", onetime=True)
+
+    class FakeClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            self.labels_ensured: list[str] = []
+
+        def initial_sync(self) -> None:
+            return None
+
+        def ensure_label_exists(self, label_name: str) -> None:
+            self.labels_ensured.append(label_name)
+
+        @property
+        def pending_changes(self) -> int:
+            return 0
+
+        def flush_queue(self) -> int:
+            return 0
+
+    class FakeDB:
+        def close(self) -> None:
+            return None
+
+    fake_client = FakeClient("token")
+    monkeypatch.setattr(entry.Config, "from_env_and_cli", lambda argv=None: config)
+    monkeypatch.setattr(entry, "setup_logging", lambda debug: None)
+    monkeypatch.setattr(entry, "TodoistClient", lambda api_key: fake_client)
+    monkeypatch.setattr(entry, "open_db", lambda db_path: FakeDB())
+    monkeypatch.setattr(entry, "run_labeling_pass", lambda client, db, cfg: 0)
+
+    rc = entry.main([])
+    assert rc == 0
+    assert fake_client.labels_ensured == ["doing_now"]
+


### PR DESCRIPTION
## Summary
This PR adds a configurable singleton reconciliation feature for a focus label (default use case: `doing_now`) and integrates it into the core labeling pass, API helpers, and debug Web UI.

### What changed
- Added `doing_now` configuration support:
  - New config field: `Config.doing_now_label`
  - New env var: `AUTODOIST_DOING_NOW_LABEL`
  - New CLI flags: `--doing_now_label` and `--doing-now-label`
- Updated runtime enablement in `__main__`:
  - Autodoist now runs when either `next_action` labeling or `doing_now` singleton mode is enabled.
  - Ensures all configured labels exist at startup (deduplicated).
- Added persistent singleton state in SQLite:
  - New table: `singleton_label_state(label_name, task_id, is_active, assigned_at)`
  - New index for active lookups.
  - New DB methods:
    - `get_active_singleton_tasks(...)`
    - `get_singleton_assigned_at(...)`
    - `set_singleton_state(...)`
- Added shared singleton winner utility module:
  - New file `autodoist/singleton.py`.
  - Deterministic winner selection with ordering:
    1. stored `assigned_at` (local assignment recency)
    2. task `updated_at`
    3. task id tie-break
- Integrated singleton reconciliation into the existing labeling planner:
  - `LabelingEngine.run()` now supports running in doing-now-only mode.
  - Added `_reconcile_singleton_label(...)` which:
    - evaluates current labels from `_get_current_labels(...)` (planner state),
    - resolves conflicts,
    - removes singleton label from losers via `_remove_label(...)`,
    - persists active/inactive singleton state transitions.
  - Keeps one consolidated label-diff path through `_commit_label_changes()`.
- API + Web integration:
  - Added API v1 helpers in `TodoistClient`:
    - `get_task_v1(...)`
    - `get_task_updated_at_v1(...)`
  - Updated Web UI reconciliation to use shared winner utility for consistent ordering semantics.
- Documentation:
  - Added `AUTODOIST_DOING_NOW_LABEL` to README env var table.
  - Added CLI example for singleton mode.

## Why
Todoist API does not expose a first-class `label_assigned_at` field for tasks. To support robust singleton focus-label enforcement without webhooks, we need local state to represent assignment recency and deterministic conflict resolution.

This implementation uses local DB state (`assigned_at`) and integrates reconciliation into the existing desired-label planner so we do not create conflicting per-task label updates in the same pass.

## How it works
1. During a pass, `LabelingEngine` builds desired labels as usual.
2. Singleton reconciliation runs against active tasks that currently include `doing_now` in planner state.
3. If multiple tasks are labeled, one winner is selected deterministically.
4. Losers have `doing_now` removed via `_remove_label(...)` (not direct API writes).
5. DB singleton state is updated (`is_active`, `assigned_at`) for future recency decisions.
6. Final label updates are queued once via existing `_commit_label_changes()`.

## Behavior and compatibility notes
- Backward compatible by default: singleton mode is off unless configured.
- Works alongside `next_action` mode without label update collisions.
- Can run in singleton-only mode (no `-l/--label` required).

## Testing
Added focused tests in `tests/test_doing_now_singleton.py` for:
- Config env/CLI parsing and precedence
- Singleton DB state roundtrip
- Labeling-engine conflict resolution behavior
- Main entrypoint running in doing-now-only mode

Local test run:
- `python -m pytest -q`
- Result: `35 passed, 16 skipped`
