### PR TITLE
Add task-level explain output for next_action and doing_now

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Useful API endpoints:
 
 - `GET /api/health` - simple health check
 - `GET /api/state` - full snapshot with tasks, labels, counts, and detected `doing_now` conflicts
+- `GET /api/explain` - per-task reason codes for `next_action` and `doing_now` decisions
 - `GET /api/tasks?label=doing_now` - filter tasks by label
 - `GET /api/tasks?contains=foo` - filter tasks by content
 - `POST /api/doing-now/reconcile` - dry-run or apply singleton reconciliation


### PR DESCRIPTION
Closes #17

## Summary
Adds deterministic task-level explain output for `next_action` and `doing_now` in the debug API, with a dedicated endpoint and test coverage.

## What changed
- Extended `GET /api/state` task payloads with `explain` data:
  - `explain.next_action`: `has_label`, `reason_code`, `reason`
  - `explain.doing_now`: `has_label`, `reason_code`, `reason`, `winner_task_id`
  - `explain.signals`: deterministic supporting signals (`is_header_task`, `section_disabled`, inferred type suffixes, conflict flag)
- Added `GET /api/explain` endpoint:
  - Returns task-focused explain payload for all tasks
  - Supports optional `task_id` query filter
- Added lightweight suffix inference helper for explain context (`-`/`=` parsing by scope width).
- Updated README endpoint list to include `/api/explain`.

## Why
This gives immediate visibility into why tasks currently have or do not have `next_action`/`doing_now`, which is the core debugging gap for workflow confidence.

## Reason code behavior
### `next_action`
- `label_present_on_active_task`
- `header_task_not_actionable`
- `section_labeling_disabled`
- `no_type_suffix_detected`
- `not_selected_by_ordering_or_rules`

### `doing_now`
- `singleton_conflict_winner`
- `singleton_conflict_loser`
- `singleton_holder`
- `singleton_assigned_to_other_task`
- `not_labeled`

## Tests
Updated `tests/test_webui.py`:
- verifies explain reason codes in `/api/state`
- verifies `/api/explain` response and payload shape
- verifies `/api/explain?task_id=...` filtering

Local run:
- `. .venv/bin/activate && python -m pytest -q`
- Result: `37 passed, 16 skipped`
