### PR TITLE
Add row-level focus and next_action task actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Useful API endpoints:
 - `GET /api/explain` - per-task reason codes for `next_action` and `focus` decisions
 - `GET /api/tasks?label=focus` - filter tasks by label
 - `GET /api/tasks?contains=foo` - filter tasks by content
+- `POST /api/tasks/<task_id>/labels` - row actions (`set_focus`, `clear_focus`, `remove_next_action`, `make_winner`)
 - `GET /api/focus/reconcile-preview` - preview winner/losers and exact label diffs before apply
 - `POST /api/focus/reconcile` - dry-run or apply singleton reconciliation
 


### PR DESCRIPTION
Closes #10

## Summary
Adds row-level task actions in the debug dashboard/API to reduce context switching:
- set/clear `focus`
- remove `next_action`
- make selected task the singleton `focus` winner during conflicts

## What changed
- UI (`autodoist/webui.py`):
  - Added an **Actions** column with per-row buttons:
    - `Set focus` / `Clear focus`
    - `Remove next_action` (when present)
    - `Make winner` (when focus conflict exists)
  - Actions call API and refresh state/preview after completion.

- API (`autodoist/webui.py`):
  - New endpoint: `POST /api/tasks/<task_id>/labels`
  - Supported actions:
    - `set_focus`
    - `clear_focus`
    - `remove_next_action`
    - `make_winner`
  - `make_winner` reuses reconcile preview logic to remove `focus` from losers consistently.

- Docs (`README.md`):
  - Added row-action endpoint to API endpoint list.

## Why
This keeps labels Todoist-native while allowing fast, low-friction triage directly in the dashboard.

## Tests
Updated `tests/test_webui.py` with coverage for:
- `set_focus`
- `clear_focus`
- `remove_next_action`
- `make_winner` conflict path
- `make_winner` no-conflict rejection

Local run:
- `. .venv/bin/activate && python -m pytest -q`
- Result: `44 passed, 16 skipped`
