### PR TITLE
Add quick filters and saved task views in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Useful API endpoints:
 - `GET /api/explain` - per-task reason codes for `next_action` and `focus` decisions
 - `GET /api/tasks?label=focus` - filter tasks by label
 - `GET /api/tasks?contains=foo` - filter tasks by content
+- `GET /api/tasks?view=next_action|focus|conflicts|no_labels` - quick triage views
 - `POST /api/tasks/<task_id>/labels` - row actions (`set_focus`, `clear_focus`, `remove_next_action`, `make_winner`)
 - `GET /api/focus/reconcile-preview` - preview winner/losers and exact label diffs before apply
 - `POST /api/focus/reconcile` - dry-run or apply singleton reconciliation

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -280,6 +280,34 @@ def test_state_endpoint_accepts_results_wrapped_payloads(monkeypatch):
     assert payload["summary"]["focus_count"] == 2
 
 
+def test_tasks_endpoint_supports_quick_views(monkeypatch):
+    client, _ = build_client(monkeypatch)
+
+    response = client.get("/api/tasks?view=next_action")
+    assert response.status_code == 200
+    assert response.get_json()["count"] == 2
+
+    response = client.get("/api/tasks?view=focus")
+    assert response.status_code == 200
+    assert response.get_json()["count"] == 2
+
+    response = client.get("/api/tasks?view=conflicts")
+    assert response.status_code == 200
+    assert response.get_json()["count"] == 2
+
+    response = client.get("/api/tasks?view=no_labels")
+    assert response.status_code == 200
+    assert response.get_json()["count"] == 0
+
+
+def test_tasks_endpoint_rejects_unknown_view(monkeypatch):
+    client, _ = build_client(monkeypatch)
+    response = client.get("/api/tasks?view=invalid")
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "Unsupported view" in payload["error"]
+
+
 def test_explain_endpoint_returns_task_reasons(monkeypatch):
     client, _ = build_client(monkeypatch)
     response = client.get("/api/explain")


### PR DESCRIPTION
Closes #8

## Summary
Adds quick triage filters and saved views to the debug dashboard.

## What changed
- Dashboard UI quick-view controls:
  - `All`
  - `Only next_action`
  - `Only focus`
  - `Conflicts only`
  - `No labels`
- Saved view persistence:
  - Selected view is persisted in `localStorage` and restored on reload.
  - Active view button is visually highlighted.
- Rendering behavior:
  - Task table renders filtered results while summary cards continue showing full-state counts.
- API support for testable quick views:
  - `GET /api/tasks?view=next_action|focus|conflicts|no_labels`
  - Invalid view returns `400`.
- README updated with the new quick-view query parameter.

## Why
This removes repetitive manual scanning in day-to-day triage and keeps a preferred view sticky across refreshes/reloads.

## Tests
Updated `tests/test_webui.py`:
- validates all `view=` modes on `/api/tasks`
- validates invalid view handling (`400`)

Local run:
- `. .venv/bin/activate && python -m pytest -q`
- Result: `46 passed, 16 skipped`
