### PR TITLE
Add persistent focus history and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Optional arguments:
 
 ```bash
 autodoist-webui --host 127.0.0.1 --port 8080 --next-action-label next_action --focus-label focus
+autodoist-webui --db-path /path/to/metadata.sqlite
 ```
 
 Then open:
@@ -241,6 +242,8 @@ Useful API endpoints:
 - `GET /api/tasks?contains=foo` - filter tasks by content
 - `GET /api/tasks?view=next_action|focus|conflicts|no_labels` - quick triage views
 - `POST /api/tasks/<task_id>/labels` - row actions (`set_focus`, `clear_focus`, `remove_next_action`, `make_winner`)
+- `GET /api/focus/history` - focus session history (supports `open_only` and `limit`)
+- `GET /api/focus/history/<task_id>` - focus history for one task
 - `GET /api/focus/reconcile-preview` - preview winner/losers and exact label diffs before apply
 - `POST /api/focus/reconcile` - dry-run or apply singleton reconciliation
 


### PR DESCRIPTION
## Summary
Implements a durable, purpose-driven focus activity log backed by SQLite and exposes it via API for backtracking previously focused work.

## What/Why
Todoist activity data does not provide reliable label-transition history for focus changes. This PR adds local persistence so we can answer questions like:
- what was focused previously?
- when did focus switch?
- which previously focused tasks are still open?

## How it works
### DB layer (`autodoist/db.py`)
- Added WAL/timeout pragmas for safer multi-process access (daemon + web UI):
  - `journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=30000`
- Added `focus_history` table and indexes:
  - stores sessions with `assigned_at`, `cleared_at`, source/reason, optional metadata
- Added idempotent session APIs:
  - `start_singleton_session(...)` (no-op if already open)
  - `end_singleton_session(...)` (no-op if no open session)
  - `list_singleton_history(...)`
- Added bulk helper:
  - `get_singleton_assigned_at_map(...)`

### Core reconciliation (`autodoist/labeling.py`)
- `_reconcile_singleton_label` now writes session transitions:
  - observed activation (`autodoist_poll`)
  - observed deactivation (`autodoist_poll`)
  - conflict loser cleanup (`autodoist_reconcile`, with winner metadata)

### Web/API integration (`autodoist/webui.py`)
- `create_app(..., db_path=...)` and new CLI arg `--db-path` (defaults to `AUTODOIST_DB_PATH`)
- winner selection now consults DB `assigned_at` map for consistency with daemon behavior
- new endpoints:
  - `GET /api/focus/history?open_only=true&limit=50`
  - `GET /api/focus/history/<task_id>?limit=50`
- row actions and reconcile apply now persist focus sessions/state immediately (`source=webui`), using idempotent DB methods

### Docs (`README.md`)
- Added `--db-path` example for web UI
- Documented focus history endpoints

## Tests
- `tests/test_focus_singleton.py`
  - added idempotent history-session test
  - validates focus conflict run writes expected history
- `tests/test_webui.py`
  - added focus history endpoint tests (`/api/focus/history`, `open_only`, per-task)
  - isolated DB path per test to avoid cross-test state coupling

Local run:
- `. .venv/bin/activate && python -m pytest -q`
- Result: `50 passed, 16 skipped`
