### PR TITLE
Add Focus History panel to Web UI (open-only by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Then open:
 
 - `http://127.0.0.1:8080/` (dashboard)
 
+Dashboard includes a **Focus History** panel that defaults to open tasks only, so you can quickly backtrack recent focus sessions that are still actionable.
+
 Useful API endpoints:
 
 - `GET /api/health` - simple health check


### PR DESCRIPTION
## Summary
Adds a Focus History panel to the Web UI dashboard so previously focused work is visible directly in the UI.

## What changed
- New **Focus History** card on the dashboard:
  - Calls `GET /api/focus/history`
  - Defaults to `open_only=true` (open tasks only)
  - Includes a checkbox toggle to include closed items
  - Includes a manual refresh button
- History panel renders:
  - task id
  - task content (or fallback if task is no longer open)
  - assigned timestamp
  - cleared timestamp / `active`
- Dashboard refresh now updates:
  - task table
  - reconcile preview
  - focus history panel
- README updated to mention the new Focus History panel behavior.

## Why
This closes the loop for backtracking focus decisions without requiring manual API calls.

## Validation
- `python -m pytest -q tests/test_webui.py` → pass
- `python -m pytest -q` → `50 passed, 16 skipped`
