### PR TITLE
Add deduped latest-per-task mode to Focus History

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Useful API endpoints:
 - `GET /api/tasks?contains=foo` - filter tasks by content
 - `GET /api/tasks?view=next_action|focus|conflicts|no_labels` - quick triage views
 - `POST /api/tasks/<task_id>/labels` - row actions (`set_focus`, `clear_focus`, `remove_next_action`, `make_winner`)
-- `GET /api/focus/history` - focus session history (supports `open_only` and `limit`)
+- `GET /api/focus/history` - focus session history (supports `open_only`, `latest_per_task`, and `limit`)
 - `GET /api/focus/history/<task_id>` - focus history for one task
 - `GET /api/focus/reconcile-preview` - preview winner/losers and exact label diffs before apply
 - `POST /api/focus/reconcile` - dry-run or apply singleton reconciliation


### PR DESCRIPTION
## Summary
Adds deduped Focus History mode so repeated focus sessions on the same task can be collapsed to one latest entry per task.

## What changed
- API:
  - `GET /api/focus/history` now supports `latest_per_task=true|false`
  - default is `latest_per_task=true`
  - response now includes `latest_per_task` field
- Web UI panel:
  - added **Latest per task** checkbox (default checked)
  - panel now requests `latest_per_task` with history fetches
- Docs:
  - README updated to include `latest_per_task` in history endpoint options

## Why
This avoids noisy repeated entries and gives a cleaner backtracking view by default, while still allowing full session history when needed.

## Tests
- Added regression test covering repeated sessions and dedupe behavior
- Verified both modes:
  - deduped (`latest_per_task=true`) returns one row per task
  - full history (`latest_per_task=false`) returns all sessions

Local run:
- `. .venv/bin/activate && python -m pytest -q`
- Result: `51 passed, 16 skipped`
