### PR TITLE
Add focus-history row actions, Todoist links, and default 5-item view

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ Then open:
 
 - `http://127.0.0.1:8080/` (dashboard)
 
-Dashboard includes a **Focus History** panel that defaults to open tasks only, so you can quickly backtrack recent focus sessions that are still actionable.
+Dashboard includes a **Focus History** panel that defaults to open tasks only and shows the latest 5 items by default (adjustable). Each row includes:
+- `Set as focus` (switches singleton focus to that task)
+- `Open in Todoist` deep link
 
 Useful API endpoints:
 


### PR DESCRIPTION
## Summary
Enhances Focus History panel UX with row-level interactions and a tighter default list size.

## What changed
- Focus History panel now defaults to showing **5** items (adjustable to 10/20/50).
- Added row-level action in history list:
  - **Set as focus** (for open tasks)
  - This sets focus on the selected task and triggers singleton reconciliation so focus switches cleanly.
- Added per-row deep link:
  - **Open in Todoist** (`https://todoist.com/showTask?id=<task_id>`)
- Existing filters remain:
  - Open tasks only
  - Latest per task

## Why
This enables direct backtracking and quick focus switching from history without leaving the dashboard, while keeping the panel concise by default.

## Validation
- `python -m pytest -q tests/test_webui.py` → pass
- `python -m pytest -q` → `51 passed, 16 skipped`
