### PR TITLE
Follow-up: fix sectionless next_action cascade and add regression test

### DIFF
--- a/autodoist/labeling.py
+++ b/autodoist/labeling.py
@@ -839,7 +839,7 @@ class LabelingEngine:
     def _same_id(left: Any, right: Any) -> bool:
         """Compare Todoist IDs defensively across str/int SDK variants."""
         if left is None or right is None:
-            return False
+            return left is None and right is None
         return str(left) == str(right)
 
     def _commit_label_changes(self) -> int:

--- a/autodoist/labeling.py
+++ b/autodoist/labeling.py
@@ -677,7 +677,8 @@ class LabelingEngine:
         
         # Position 2: subtask-level behavior
         subtask_mode = dominant_type[2]
-        
+        parent_labels = self._get_current_labels(task)
+
         if subtask_mode == 's':
             # Sequential: label first non-completed child, remove from parent
             labeled_first = False
@@ -692,15 +693,17 @@ class LabelingEngine:
                 self.db.set_parent_type(str(child.id), subtask_mode)
                 
                 # Label first child if parent has label
-                if not labeled_first and not child.is_completed and label in task.labels:
+                if not labeled_first and not child.is_completed and label in parent_labels:
                     self._add_label(child, label)
                     self._remove_label(task, label)
+                    parent_labels = self._get_current_labels(task)
                     labeled_first = True
                     
         elif subtask_mode == 'p':
             # Parallel: label all children, remove from parent
-            if label in task.labels:
+            if label in parent_labels:
                 self._remove_label(task, label)
+                parent_labels = self._get_current_labels(task)
             
             for child in child_tasks:
                 if is_header_task(child.content):

--- a/tests/test_labeling_engine_regressions.py
+++ b/tests/test_labeling_engine_regressions.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Any
+
+from autodoist.config import Config
+from autodoist.db import MetadataDB
+from autodoist.labeling import LabelingEngine
+
+
+@dataclass
+class MockProject:
+    id: str | int
+    name: str
+    is_inbox_project: bool = False
+
+
+@dataclass
+class MockTask:
+    id: str | int
+    content: str
+    project_id: str | int
+    section_id: Optional[str | int]
+    parent_id: Optional[str | int]
+    order: int
+    labels: list[str]
+    is_completed: bool = False
+    due: Any = None
+
+
+class MockClient:
+    def __init__(self, projects: list[MockProject], tasks: list[MockTask]) -> None:
+        self._projects = projects
+        self._tasks = tasks
+        self.queued_updates: dict[str, list[str]] = {}
+
+    def get_all_projects(self) -> list[MockProject]:
+        return self._projects
+
+    def get_all_sections(self) -> list[Any]:
+        return []
+
+    def get_all_tasks(self) -> list[MockTask]:
+        return self._tasks
+
+    def queue_label_update(self, task_id: str, labels: list[str]) -> None:
+        self.queued_updates[str(task_id)] = list(labels)
+
+    def update_task_via_rest(self, task_id: str | int, **kwargs: Any) -> None:
+        return None
+
+    def update_section_via_rest(self, section_id: str | int, **kwargs: Any) -> None:
+        return None
+
+    def update_project_via_rest(self, project_id: str | int, **kwargs: Any) -> None:
+        return None
+
+
+def _open_test_db(tmp_path: Path) -> MetadataDB:
+    db = MetadataDB(str(tmp_path / "metadata.sqlite"), auto_commit=False)
+    db.connect()
+    return db
+
+
+def test_sectionless_parent_cascades_next_action_to_first_child_without_flipflop(tmp_path: Path) -> None:
+    """
+    Regression:
+    - sectionless tasks must still be processed (NoSection id None handling)
+    - parent->child cascade should use desired labels in-pass, not stale task.labels
+    """
+    project = MockProject(id=1, name="Work ---")
+    parent = MockTask(
+        id=100,
+        content="Parent task",
+        project_id="1",  # mixed type vs project.id
+        section_id=None,
+        parent_id=None,
+        order=1,
+        labels=[],
+    )
+    child1 = MockTask(
+        id="200",
+        content="First child",
+        project_id="1",
+        section_id=None,
+        parent_id=100,  # mixed type vs parent.id
+        order=1,
+        labels=[],
+    )
+    child2 = MockTask(
+        id="201",
+        content="Second child",
+        project_id="1",
+        section_id=None,
+        parent_id="100",
+        order=2,
+        labels=[],
+    )
+
+    client = MockClient([project], [parent, child1, child2])
+    db = _open_test_db(tmp_path)
+    try:
+        engine = LabelingEngine(client=client, db=db, config=Config(api_key="x", label="next_action"))
+        changes = engine.run()
+
+        assert changes == 1
+        assert client.queued_updates == {"200": ["next_action"]}
+    finally:
+        db.close()


### PR DESCRIPTION
## Context
PR #29 fixed parent/subtask oscillation by normalizing Todoist ID comparisons.

After that merged, we found a follow-up bug affecting sectionless tasks:
- `NoSection` matching was too strict in one helper path, so `section_id=None` tasks could be skipped.
- subtask cascade checked raw `task.labels` instead of tracked desired labels, which can miss same-pass parent->child cascade decisions.

## What
- Fix `NoSection` matching for `None` identifiers in ID helper.
- In `_label_task_with_children`, use tracked desired labels (`_get_current_labels(task)`) instead of raw `task.labels` when deciding whether to cascade label from parent to child.
- Add regression coverage in `tests/test_labeling_engine_regressions.py` for sectionless parent->child cascade with mixed ID types.

## Why this matters
Without this follow-up, top-level project tasks with subtasks can end up with no `next_action` assigned in scenarios that should label the first child.

## Validation
- `uv run pytest -q tests/test_labeling_engine_regressions.py`
- `uv run pytest -q tests/test_inbox_contract.py tests/test_subtask_labeling.py tests/test_sequential_labeling.py tests/test_parallel_labeling.py tests/test_parent_id_handling.py tests/test_webui.py`
